### PR TITLE
Deploy 351

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Eclipse
+.classpath
+.settings
+.project
+
+# Intellij
+.idea/
+*.iml
+*.iws
+
+# Visual Studio Code
+.vscode/
+
+# Mac
+.DS_Store
+
+# Maven
+target
+
+*.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Alfresco Base Tomcat Image
 # see also https://github.com/docker-library/tomcat/blob/master/8.5/jre8/Dockerfile
-FROM quay.io/alfresco/alfresco-base-java:8u161-oracle-centos-7.4-341879152c62
+FROM quay.io/alfresco/alfresco-base-java:8u161-oracle-centos-7-333472fed423
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Alfresco Base Tomcat Image
 # see also https://github.com/docker-library/tomcat/blob/master/8.5/jre8/Dockerfile
-FROM quay.io/alfresco/alfresco-base-java:0.1.0
+FROM quay.io/alfresco/alfresco-base-java:8u161-oracle-centos-7.4-341879152c62
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH

--- a/build.properties
+++ b/build.properties
@@ -1,2 +1,2 @@
 DOCKER_IMAGE_REPOSITORY=alfresco-base-tomcat
-DOCKER_IMAGE_TAG=0.1.0
+DOCKER_IMAGE_TAG=8.5.23-8u161-oracle-centos-7.4

--- a/build.properties
+++ b/build.properties
@@ -1,2 +1,2 @@
 DOCKER_IMAGE_REPOSITORY=alfresco-base-tomcat
-DOCKER_IMAGE_TAG=8.5.23-java-8-oracle-centos-7.4
+DOCKER_IMAGE_TAG=8.5.23-java-8-oracle-centos-7

--- a/build.properties
+++ b/build.properties
@@ -1,2 +1,2 @@
 DOCKER_IMAGE_REPOSITORY=alfresco-base-tomcat
-DOCKER_IMAGE_TAG=8.5.23-java-8u161-oracle-centos-7.4
+DOCKER_IMAGE_TAG=8.5.23-java-8-oracle-centos-7.4

--- a/build.properties
+++ b/build.properties
@@ -1,2 +1,2 @@
 DOCKER_IMAGE_REPOSITORY=alfresco-base-tomcat
-DOCKER_IMAGE_TAG=8.5.23-8u161-oracle-centos-7.4
+DOCKER_IMAGE_TAG=8.5.23-java-8u161-oracle-centos-7.4


### PR DESCRIPTION
Updated the base java image to that built in DEPLOY-350 with the explicit tag name as decided upon by @rgauss .

Set tag to version that follows [ADR 0007](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/adrs/0007-naming-and-versioning.md)

`8.5.23-java-8u161-oracle-centos-7.4` is

- artifact-version: `8.5.23`
- dependency: `java`
- dependency flavor/version: `8u161-oracle`
- dependency: `centos`
- dependency flavor/version: `7.4`
