### PR TITLE
REPO-3275: Secure tomcat in Alfresco Content Services docker images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,5 +126,19 @@ RUN set -e \
 		exit 1; \
 	fi
 
+# Security improvements:
+# Remove server banner
+RUN sed -i "s/\    <Connector\ port=\"8080\"\ protocol=\"HTTP\/1.1\"/\    <Connector\ port=\"8080\"\ protocol=\"HTTP\/1.1\"\n\               Server=\" \"/g" /usr/local/tomcat/conf/server.xml && \
+# Add httpOnly flag to Cookies
+    sed -i "s/\    <\/session-config>/\        <cookie-config>\n\            <http-only>true<\/http-only> \n\            <secure>true<\/secure>\n\        <\/cookie-config>\n\    <\/session-config>/g" /usr/local/tomcat/conf/web.xml && \
+# Removal of default/unwanted Applications
+    rm -f -r -d /usr/local/tomcat/webapps/* && \
+# Change SHUTDOWN port and command.
+#     sed -i "s/<Server\ port=\"8005\"\ shutdown=\"SHUTDOWN\">/<Server\ port=\"ShutDownPort\"\ shutdown=\"ShutDownCommand\">/g" /usr/local/tomcat/conf/server.xml \
+# Replace default 404,403,500 page
+      sed -i "$ d" /usr/local/tomcat/conf/web.xml && \
+      sed -i -e "\$a\    <error-page\>\n\        <error-code\>404<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\    <error-page\>\n\        <error-code\>403<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\    <error-page\>\n\        <error-code\>500<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\n\<\/web-app\>" /usr/local/tomcat/conf/web.xml
+
 EXPOSE 8080
-CMD ["catalina.sh", "run"]
+# Starting tomcat with Security Manager
+CMD ["catalina.sh", "run", "-security"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,18 @@ RUN set -eux; \
       cyrus-sasl-devel openldap-devel make kernel-headers glibc-headers glibc-devel libsepol-devel \
       pcre-devel libselinux-devel libcom_err-devel libverto-devel expat-devel keyutils-libs-devel \
       krb5-devel zlib-devel openssl-devel apr-util-devel gcc openssl automake wget ; \
+    # Security improvements:
+    # Remove server banner
+    sed -i "s/\    <Connector\ port=\"8080\"\ protocol=\"HTTP\/1.1\"/\    <Connector\ port=\"8080\"\ protocol=\"HTTP\/1.1\"\n\               Server=\" \"/g" /usr/local/tomcat/conf/server.xml ; \
+    # Add httpOnly flag to Cookies
+    sed -i "s/\    <\/session-config>/\        <cookie-config>\n\            <http-only>true<\/http-only> \n\            <secure>true<\/secure>\n\        <\/cookie-config>\n\    <\/session-config>/g" /usr/local/tomcat/conf/web.xml ; \
+    # Removal of default/unwanted Applications
+    rm -f -r -d /usr/local/tomcat/webapps/* ; \
+    # Change SHUTDOWN port and command.
+    #     sed -i "s/<Server\ port=\"8005\"\ shutdown=\"SHUTDOWN\">/<Server\ port=\"ShutDownPort\"\ shutdown=\"ShutDownCommand\">/g" /usr/local/tomcat/conf/server.xml ; \
+    # Replace default 404,403,500 page
+    sed -i "$ d" /usr/local/tomcat/conf/web.xml ; \
+    sed -i -e "\$a\    <error-page\>\n\        <error-code\>404<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\    <error-page\>\n\        <error-code\>403<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\    <error-page\>\n\        <error-code\>500<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\n\<\/web-app\>" /usr/local/tomcat/conf/web.xml ; \
    yum clean all
 
 # verify Tomcat Native is working properly
@@ -125,19 +137,6 @@ RUN set -e \
 		echo >&2 "$nativeLines"; \
 		exit 1; \
 	fi
-
-# Security improvements:
-# Remove server banner
-RUN sed -i "s/\    <Connector\ port=\"8080\"\ protocol=\"HTTP\/1.1\"/\    <Connector\ port=\"8080\"\ protocol=\"HTTP\/1.1\"\n\               Server=\" \"/g" /usr/local/tomcat/conf/server.xml && \
-# Add httpOnly flag to Cookies
-    sed -i "s/\    <\/session-config>/\        <cookie-config>\n\            <http-only>true<\/http-only> \n\            <secure>true<\/secure>\n\        <\/cookie-config>\n\    <\/session-config>/g" /usr/local/tomcat/conf/web.xml && \
-# Removal of default/unwanted Applications
-    rm -f -r -d /usr/local/tomcat/webapps/* && \
-# Change SHUTDOWN port and command.
-#     sed -i "s/<Server\ port=\"8005\"\ shutdown=\"SHUTDOWN\">/<Server\ port=\"ShutDownPort\"\ shutdown=\"ShutDownCommand\">/g" /usr/local/tomcat/conf/server.xml \
-# Replace default 404,403,500 page
-      sed -i "$ d" /usr/local/tomcat/conf/web.xml && \
-      sed -i -e "\$a\    <error-page\>\n\        <error-code\>404<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\    <error-page\>\n\        <error-code\>403<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\    <error-page\>\n\        <error-code\>500<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\n\<\/web-app\>" /usr/local/tomcat/conf/web.xml
 
 EXPOSE 8080
 # Starting tomcat with Security Manager


### PR DESCRIPTION
   Remove server banner
   Add httpOnly flag to Cookies
   Replace default 404,403,500 error page
   Start tomcat with Security Manager
   Add example of command that changes shutdown port and command for tomcat.