### PR TITLE
DEPLOY-433: DOCKER_IMAGE_TAG_SHORT_NAME missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,6 @@ WORKDIR $CATALINA_HOME
 ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
 
-# runtime dependencies for Tomcat Native Libraries
-# Tomcat Native 1.2+ requires a newer version of OpenSSL than debian:jessie has available
-# > checking OpenSSL library version >= 1.0.2...
-# > configure: error: Your version of OpenSSL is not compatible with this version of tcnative
-# see http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5046024.html (and following discussion)
-# and https://github.com/docker-library/tomcat/pull/31
-ENV OPENSSL_VERSION 1.0.2k-8.el7
-
 # see https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/KEYS
 # see also "update.sh" (https://github.com/docker-library/tomcat/blob/master/update.sh)
 ENV GPG_KEYS 05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42 47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7 61B832AC2F1C5A90F0F9B00A1C506407564C17A3 713DA88BE50911535FE716F5208B0AB1D63011C7 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED 9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
@@ -53,7 +45,7 @@ ENV TOMCAT_ASC_URLS \
 
 RUN set -eux; \
   # CentOS specific addition: Install RPMs needed to build Tomcat Native Library \
-  yum install -y apr apr-devel apr-util apr-util-devel openssl-$OPENSSL_VERSION openssl-devel-$OPENSSL_VERSION \
+  yum install -y apr apr-devel apr-util apr-util-devel openssl openssl-devel \
      wget gcc automake autoconf ; \
   # Official tomcat Dockerfile section: Download, build and remove source of Tomcat Native Library \
 	success=; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Alfresco Base Tomcat Image
 # see also https://github.com/docker-library/tomcat/blob/master/8.5/jre8/Dockerfile
-FROM quay.io/alfresco/alfresco-base-java:8u161-oracle-centos-7-b5f3c2d4c871
+FROM quay.io/alfresco/alfresco-base-java:8u161-oracle-centos-7-ce1a67232405
 
 LABEL name="Alfresco Base Tomcat" \
     vendor="Alfresco" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,19 @@ ENV TOMCAT_ASC_URLS \
 
 RUN set -eux; \
   # CentOS specific addition: Install RPMs needed to build Tomcat Native Library \
-  yum install -y apr apr-devel apr-util apr-util-devel openssl openssl-devel \
-     wget gcc automake autoconf ; \
+	# We're version-pinning to improve the chances of repeatable builds. [DEPLOY-433] \
+	# openssl's version is always the same as the openssl-libs RPM already installed \
+  yum install -y \
+		apr-1.4.8-3.el7_4.1 \
+		apr-devel \
+		apr-util-1.5.2-6.el7 \
+		apr-util-devel \
+		openssl \
+		openssl-devel \
+		wget-1.14-15.el7_4.1 \
+		gcc-4.8.5-28.el7_5.1 \
+		automake-1.13.4-3.el7 \
+		autoconf-2.69-11.el7 ; \
   # Official tomcat Dockerfile section: Download, build and remove source of Tomcat Native Library \
 	success=; \
 	for url in $TOMCAT_TGZ_URLS; do \

--- a/build.properties
+++ b/build.properties
@@ -1,2 +1,3 @@
 DOCKER_IMAGE_REPOSITORY=alfresco-base-tomcat
 DOCKER_IMAGE_TAG=8.5.28-java-8-oracle-centos-7
+DOCKER_IMAGE_TAG_SHORT_NAME=8.5


### PR DESCRIPTION
The only change since the prior PR is: https://github.com/Alfresco/alfresco-docker-base-tomcat/commit/68e43ecd1a6334cd8735162e6922585bb3e7cd2f 

Until fixed, it doesn't create an updated `8.5` tag, but a garbage tag, instead.

<img width="548" alt="bamboo-inject-oops" src="https://user-images.githubusercontent.com/59195/40777081-ab31ebb0-64c4-11e8-9ebc-1d0e431dc070.png">
