### PR TITLE
DEPLOY-633 Java 11.0.1

### DIFF
--- a/scripts/etc/images.sh
+++ b/scripts/etc/images.sh
@@ -28,7 +28,7 @@ export -A java_8=(
 )
 
 export -A java_11=(
-  [base_tag]=11-openjdk-centos-7-95536c8b599f
+  [base_tag]=11.0.1-openjdk-centos-7-1fd3c4475374
   [short_tag]='true'
 )
 


### PR DESCRIPTION
Base off latest Java image.

Tested locally via  `docker run --rm -ti -p 8080:8080 -v /Users/ndoye/<mumble>/web:/usr/local/tomcat/webapps/ROOT quay.io/alfresco/alfresco-base-tomcat:8.5.34-java-11-openjdk-centos-7-DEPLOY-633`