### PR TITLE
Update wget and gcc packages version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,8 @@ RUN set -eux; \
 		apr-util-devel \
 		openssl \
 		openssl-devel \
-		wget-1.14-15.el7_4.1 \
-		gcc-4.8.5-28.el7_5.1 \
+		wget-1.14-18.el7.x86_64 \
+		gcc-4.8.5-36.el7.x86_64 \
 		automake-1.13.4-3.el7 \
 		autoconf-2.69-11.el7 ; \
 	export GNUPGHOME="$(mktemp -d)"; \


### PR DESCRIPTION
Bamboo build -> https://bamboo.alfresco.com/bamboo/browse/PS-DBTIR  was failing because:
```
No package wget-1.14-15.el7_4.1 available.
No package gcc-4.8.5-28.el7_5.1 available.
```
I have updated only these packages to:
```
wget-1.14-18.el7.x86_64
gcc-4.8.5-36.el7.x86_64
```
Green build on brach -> https://bamboo.alfresco.com/bamboo/browse/PS-DBTIR6