### PR TITLE
DEVOPS-25 fix vulns on base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN set -eux; \
 	[ ${CENTOS_MAJOR} = 7 ] && deps=" \
 		apr-1.4.8-7.el7 \
 	"; \
+	[ ${CENTOS_MAJOR} = 8 ] && yum update -y; \
 	[ ${CENTOS_MAJOR} = 8 ] && deps=" \
 		apr-1.6.3-11.el8 \
 	"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,11 +102,11 @@ RUN set -eux; \
 	"; \
 	[ ${CENTOS_MAJOR} = 8 ] && nativeBuildDeps=" \
 		apr-devel-1.6.3-11.el8 \
-		gcc-8.3.1-5.1.el8 \
+		gcc-8.4.1-1.el8 \
 		make-4.2.1-10.el8 \
 		openssl-devel-1.1.1g-15.el8_3 \
-		redhat-rpm-config-123-1.el8 \
-		glibc-all-langpacks-2.28-127.el8 \
+		redhat-rpm-config-125-1.el8 \
+		glibc-all-langpacks-2.28-151.el8 \
 	"; \
 	yum install -y $nativeBuildDeps; \
 	( \
@@ -120,7 +120,7 @@ RUN set -eux; \
 		make -j "$(nproc)"; \
 		make install; \
 	); \
-	yum history -y rollback last-1; \
+	yum remove -y $nativeBuildDeps; \
 	find /etc -mindepth 2 -name *.rpmsave -exec rm -v '{}' +; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ RUN set -eux; \
 		make -j "$(nproc)"; \
 		make install; \
 	); \
-	yum remove -y $nativeBuildDeps; \
+	yum history -y rollback last-1; \
 	find /etc -mindepth 2 -name *.rpmsave -exec rm -v '{}' +; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \

--- a/java-11/centos-7/Dockerfile
+++ b/java-11/centos-7/Dockerfile
@@ -1,2 +1,2 @@
 # Java 11 Centos 7 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:11.0.11-centos-7@sha256:e71eebc18aded9c42e8c1e78f8c6f5cdc9096359e45840006fb6327222506f92
+FROM alfresco/alfresco-base-java:11.0.11-centos-7@sha256:1ac1a40de23620c3915b1d57cbce9f149f8fc1b1991a538e00e8dce93ebe6d1b

--- a/java-11/centos-7/Dockerfile
+++ b/java-11/centos-7/Dockerfile
@@ -1,2 +1,2 @@
 # Java 11 Centos 7 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:11.0.11-centos-7@sha256:9528ccd7f9e18f74e95c0393c6719f33daf51cb7a17c4d12c7f8623550ce3309
+FROM alfresco/alfresco-base-java:11.0.11-centos-7@sha256:e71eebc18aded9c42e8c1e78f8c6f5cdc9096359e45840006fb6327222506f92

--- a/java-11/centos-8/Dockerfile
+++ b/java-11/centos-8/Dockerfile
@@ -1,2 +1,2 @@
 # Java 11 Centos 8 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:11.0.11-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
+FROM alfresco/alfresco-base-java:11.0.11-centos-8@sha256:97e280c81727c540cc0b2e61c8b3234f641a9bc1ee45e011dd668faa523eca3b

--- a/java-11/centos-8/Dockerfile
+++ b/java-11/centos-8/Dockerfile
@@ -1,2 +1,2 @@
 # Java 11 Centos 8 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:11.0.11-centos-8@sha256:97e280c81727c540cc0b2e61c8b3234f641a9bc1ee45e011dd668faa523eca3b
+FROM alfresco/alfresco-base-java:11.0.11-centos-8@sha256:91627e3fb0cce0348de66fe42c5c39a7a872a23dbf35714efa255673a3b71aaa

--- a/java-8/centos-7/Dockerfile
+++ b/java-8/centos-7/Dockerfile
@@ -1,2 +1,2 @@
 # Java 8 Centos 7 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:8.0.292-centos-7@sha256:1f6c61e0322240d6a5dd91eacd7fe822d188b4299fde9fd10e2c04fcfc236a74
+FROM alfresco/alfresco-base-java:8.0.292-centos-7@sha256:37e97c05917bfd2e3c4751c1c50f798c38f39a5c4df3c7a735e002457af88af8

--- a/java-8/centos-7/Dockerfile
+++ b/java-8/centos-7/Dockerfile
@@ -1,2 +1,2 @@
 # Java 8 Centos 7 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:8.0.292-centos-7@sha256:13ad5142d5577bc52b4757b6727435c8634e9c80b9c44ccfa34fcdb857bcfbea
+FROM alfresco/alfresco-base-java:8.0.292-centos-7@sha256:1f6c61e0322240d6a5dd91eacd7fe822d188b4299fde9fd10e2c04fcfc236a74

--- a/java-8/centos-8/Dockerfile
+++ b/java-8/centos-8/Dockerfile
@@ -1,2 +1,2 @@
 # Java 8 Centos 8 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:8.0.292-centos-8@sha256:80113be2358f851b57aedf7059223a7bb9b5370b0b4f8ef5164113fb0d0f478b
+FROM alfresco/alfresco-base-java:8.0.292-centos-8@sha256:70cb44e7e7097a375a7e68d0d67c6fb76bcfeed455e25d682c783e4712c69298

--- a/java-8/centos-8/Dockerfile
+++ b/java-8/centos-8/Dockerfile
@@ -1,2 +1,2 @@
 # Java 8 Centos 8 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:8.0.292-centos-8@sha256:ccbf6085c38faea1662e4034511e2b6f352fdebd6305768845e239ce9c6475df
+FROM alfresco/alfresco-base-java:8.0.292-centos-8@sha256:80113be2358f851b57aedf7059223a7bb9b5370b0b4f8ef5164113fb0d0f478b


### PR DESCRIPTION
- DEVOPS-25 update vulns
- Bump alfresco/alfresco-base-java in /java-11/centos-8
- Bump alfresco/alfresco-base-java in /java-8/centos-8
- centos 7 updates
