### PR TITLE
add remoteIP valve to tomcat image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,8 +141,11 @@ RUN set -eux; \
 	chmod 777 logs work ; \
 	\
 	# Security improvements:
-	# Remove server banner
-	sed -i "s/\    <Connector\ port=\"8080\"\ protocol=\"HTTP\/1.1\"/\    <Connector\ port=\"8080\"\ protocol=\"HTTP\/1.1\"\n\               Server=\" \"/g" /usr/local/tomcat/conf/server.xml ; \
+	# Remove server banner, Turn off loggin by the VersionLoggerListener, enable remoteIP valve so we know who we're talking to
+	sed -i \
+          -e "s/\  <Listener\ className=\"org.apache.catalina.startup.VersionLoggerListener\"/\  <Listener\ className=\"org.apache.catalina.startup.VersionLoggerListener\"\ logArgs=\"false\"/g" \
+          -e "s%\(^\s*</Host>\)%\t<Valve className=\"org.apache.catalina.valves.RemoteIpValve\" />\n\n\1%" \
+          -e "s/\    <Connector\ port=\"8080\"\ protocol=\"HTTP\/1.1\"/\    <Connector\ port=\"8080\"\ protocol=\"HTTP\/1.1\"\n\               Server=\" \"/g" /usr/local/tomcat/conf/server.xml; \
 	# Removal of default/unwanted Applications
 	rm -f -r -d /usr/local/tomcat/webapps/* ; \
 	# Change SHUTDOWN port and command.
@@ -150,8 +153,6 @@ RUN set -eux; \
 	# Replace default 404,403,500 page
 	sed -i "$ d" /usr/local/tomcat/conf/web.xml ; \
 	sed -i -e "\$a\    <error-page\>\n\        <error-code\>404<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\    <error-page\>\n\        <error-code\>403<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\    <error-page\>\n\        <error-code\>500<\/error-code\>\n\        <location\>\/error.jsp<\/location\>\n\    <\/error-page\>\n\n\<\/web-app\>" /usr/local/tomcat/conf/web.xml ; \
-	#Turn off loggin by the VersionLoggerListener
-	sed -i "s/\  <Listener\ className=\"org.apache.catalina.startup.VersionLoggerListener\"/\  <Listener\ className=\"org.apache.catalina.startup.VersionLoggerListener\"\ logArgs=\"false\"/g" /usr/local/tomcat/conf/server.xml ; \
 	yum clean all
 
 # verify Tomcat Native is working properly


### PR DESCRIPTION
Adding RemoteIP tomcat Valve to the servlet container config as it work better in proxied setup and allow for proper keycloak https config (require appropriate client app config too, see OPSEXP-939)