### PR TITLE
OPSEXP-1037 use base image with exported JAVA_HOME

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ branches:
     - master
 
 env:
-  - DIST_NAME=centos DIST_MAJOR=7 JAVA_MAJOR=8  TOMCAT_MAJOR=8
-  - DIST_NAME=centos DIST_MAJOR=7 JAVA_MAJOR=11 TOMCAT_MAJOR=8
-  - DIST_NAME=centos DIST_MAJOR=7 JAVA_MAJOR=11 TOMCAT_MAJOR=9
-  - DIST_NAME=centos DIST_MAJOR=7 JAVA_MAJOR=11 TOMCAT_MAJOR=10
+  - DISTRIB_NAME=centos DISTRIB_MAJOR=7 JAVA_MAJOR=8  TOMCAT_MAJOR=8
+  - DISTRIB_NAME=centos DISTRIB_MAJOR=7 JAVA_MAJOR=11 TOMCAT_MAJOR=8
+  - DISTRIB_NAME=centos DISTRIB_MAJOR=7 JAVA_MAJOR=11 TOMCAT_MAJOR=9
+  - DISTRIB_NAME=centos DISTRIB_MAJOR=7 JAVA_MAJOR=11 TOMCAT_MAJOR=10
 
 before_script:
   - export BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
@@ -23,16 +23,16 @@ before_script:
     export TOMCAT_VERSION=$(grep "ENV TOMCAT_VERSION $TOMCAT_MAJOR" Dockerfile | cut -d ' ' -f 3)
     export IMAGE_REGISTRY_NAMESPACE=alfresco
     export IMAGE_REPOSITORY=alfresco-base-tomcat
-    export IMAGE_TAG=$TOMCAT_VERSION-java-$JAVA_MAJOR-$DIST_NAME-$DIST_MAJOR
+    export IMAGE_TAG=$TOMCAT_VERSION-java-$JAVA_MAJOR-$DISTRIB_NAME-$DISTRIB_MAJOR
 
 script:
   - |-
     set -ex
 
-    (cd java-$JAVA_MAJOR/$DIST_NAME-$DIST_MAJOR && docker build -t java-$JAVA_MAJOR-$DIST_NAME-$DIST_MAJOR .)
+    (cd java-$JAVA_MAJOR/$DISTRIB_NAME-$DISTRIB_MAJOR && docker build -t java-$JAVA_MAJOR-$DISTRIB_NAME-$DISTRIB_MAJOR .)
     docker build -t $IMAGE_REPOSITORY . \
-      --build-arg DIST_NAME=$DIST_NAME \
-      --build-arg DIST_MAJOR=$DIST_MAJOR \
+      --build-arg DISTRIB_NAME=$DISTRIB_NAME \
+      --build-arg DISTRIB_MAJOR=$DISTRIB_MAJOR \
       --build-arg JAVA_MAJOR=$JAVA_MAJOR \
       --build-arg TOMCAT_MAJOR=$TOMCAT_MAJOR \
       --build-arg REVISION=$TRAVIS_COMMIT \
@@ -49,7 +49,7 @@ script:
       export SHORT_SHA256=$(docker image inspect -f '{{ printf "%.12s" (index (split (index .RepoDigests 0) ":") 1) }}' $IMAGE_REPOSITORY)
       echo SHORT_SHA256=$SHORT_SHA256
       TAGS=($IMAGE_TAG $IMAGE_TAG-$SHORT_SHA256)
-      [[ $DISTRIB_NAME == 'centos' && $DIST_MAJOR == 7 && $JAVA_VERSION == 11 ]] && TAGS+=(${TOMCAT_VERSION%.*})
+      [[ $DISTRIB_NAME == 'centos' && $DISTRIB_MAJOR == 7 && $JAVA_VERSION == 11 ]] && TAGS+=(${TOMCAT_VERSION%.*})
       for IMAGE_REGISTRY in quay.io docker.io
       do
         echo "tagging and pushing to $IMAGE_REGISTRY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,6 @@ RUN set -eux; \
 	yum clean all
 
 # verify Tomcat Native is working properly
-RUN catalina.sh configtest 2>&1
 RUN set -e \
 	&& nativeLines="$(catalina.sh configtest 2>&1 | grep -c 'Loaded Apache Tomcat Native library')" \
 	&& test $nativeLines -ge 1 || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ RUN set -eux; \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
 		./configure \
+			--with-java-home="$JDK_HOME" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$(which apr-1-config)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,8 @@ RUN set -eux; \
 	rm tomcat.tar.gz*; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
+	[ ${JAVA_MAJOR} == 8 ] && JAVA_MAJOR_PKG=1.8.0; \
+	JRE_PKG_VERSION=$(rpm -qa java-${JAVA_MAJOR_PKG:-$JAVA_MAJOR}-openjdk-headless --queryformat "%{RPMTAG_VERSION}"); \
 	tar -xvf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
 	[ ${DIST_MAJOR} = 7 ] && nativeBuildDeps=" \
 		apr-devel-1.4.8-7.el7 \
@@ -115,6 +117,7 @@ RUN set -eux; \
 		redhat-rpm-config-125-1.el8 \
 		glibc-all-langpacks-2.28-151.el8 \
 	"; \
+	nativeBuildDeps="$nativeBuildDeps java-${JAVA_MAJOR_PKG:-$JAVA_MAJOR}-openjdk-devel-${JRE_PKG_VERSION}"; \
 	yum install -y $nativeBuildDeps; \
 	( \
 		export CATALINA_HOME="$PWD"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,7 @@ RUN set -eux; \
 	yum clean all
 
 # verify Tomcat Native is working properly
+RUN catalina.sh configtest 2>&1
 RUN set -e \
 	&& nativeLines="$(catalina.sh configtest 2>&1 | grep -c 'Loaded Apache Tomcat Native library')" \
 	&& test $nativeLines -ge 1 || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,28 @@
 # Alfresco Base Tomcat Image
 # see also https://github.com/docker-library/tomcat
 ARG JAVA_MAJOR
-ARG DIST_NAME
-ARG DIST_MAJOR
+ARG DISTRIB_NAME
+ARG DISTRIB_MAJOR
 ARG TOMCAT_MAJOR
 
-FROM java-$JAVA_MAJOR-$DIST_NAME-$DIST_MAJOR AS tomcat-8
+FROM java-$JAVA_MAJOR-$DISTRIB_NAME-$DISTRIB_MAJOR AS tomcat-8
 ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.5.65
 ENV TOMCAT_SHA512 eb5a77d75a46496f7de39c1cba5f4fc4991ec7da7717e7b37ad48b4ca2ea334aeabfd094f64977477b4b2352637b56e30e5d9acfcdf7ccd5f4269a824829dd39
 
-FROM java-$JAVA_MAJOR-$DIST_NAME-$DIST_MAJOR AS tomcat-9
+FROM java-$JAVA_MAJOR-$DISTRIB_NAME-$DISTRIB_MAJOR AS tomcat-9
 ENV TOMCAT_MAJOR 9
 ENV TOMCAT_VERSION 9.0.45
 ENV TOMCAT_SHA512 81bfbd1f13dabc178635a2841c1566d080e209dff36170f6f4f354e3b2b3878f603fc8978c0c132655fca3653166e68094d61c3dcfc5edf07bc7e5419d20c0d1
 
-FROM java-$JAVA_MAJOR-$DIST_NAME-$DIST_MAJOR AS tomcat-10
+FROM java-$JAVA_MAJOR-$DISTRIB_NAME-$DISTRIB_MAJOR AS tomcat-10
 ENV TOMCAT_MAJOR 10
 ENV TOMCAT_VERSION 10.0.8
 ENV TOMCAT_SHA512 188fb84f86ae5f5b88ddbe6f38c8dec6ec733a5ef166c5875e1c6728701e49f9d01f494a419186fd8da80ab21576e0a056382d59f7fe17695c4ec63aaf543897
 
 FROM tomcat-$TOMCAT_MAJOR
 ARG JAVA_MAJOR
-ARG DIST_MAJOR
+ARG DISTRIB_MAJOR
 ARG CREATED
 ARG REVISION
 
@@ -64,12 +64,11 @@ RUN set -eux; \
 	# CentOS specific addition: Install RPMs needed to build Tomcat Native Library \
 	# We're version-pinning to improve the chances of repeatable builds. [DEPLOY-433] \
 	# openssl's version is always the same as the openssl-libs RPM already installed \
-	[ ${DIST_MAJOR} = 7 ] && deps=" \
+	[[ ${DISTRIB_MAJOR} = 7 && ${JAVA_MAJOR} = 8 ]] && deps="\
 		apr-1.4.8-7.el7 \
 	"; \
-	[ ${DIST_MAJOR} = 8 ] && yum update -y; \
-	[ ${DIST_MAJOR} = 8 ] && deps=" \
-		apr-1.6.3-11.el8 \
+	[[ ${DISTRIB_MAJOR} = 7 && ${JAVA_MAJOR} = 11 ]] && deps="\
+		apr-1.4.8-7.el7 \
 	"; \
 	yum install -y $deps; \
 	curl -fsSL https://www.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR}/KEYS | gpg --import; \
@@ -103,19 +102,11 @@ RUN set -eux; \
 	[ ${JAVA_MAJOR} == 8 ] && JAVA_MAJOR_PKG=1.8.0; \
 	JRE_PKG_VERSION=$(rpm -qa java-${JAVA_MAJOR_PKG:-$JAVA_MAJOR}-openjdk-headless --queryformat "%{RPMTAG_VERSION}"); \
 	tar -xvf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	[ ${DIST_MAJOR} = 7 ] && nativeBuildDeps=" \
+	[ ${DISTRIB_MAJOR} = 7 ] && nativeBuildDeps=" \
 		apr-devel-1.4.8-7.el7 \
 		gcc-4.8.5-44.el7 \
 		make-3.82-24.el7 \
 		openssl-devel-1.0.2k-21.el7_9 \
-	"; \
-	[ ${DIST_MAJOR} = 8 ] && nativeBuildDeps=" \
-		apr-devel-1.6.3-11.el8 \
-		gcc-8.4.1-1.el8 \
-		make-4.2.1-10.el8 \
-		openssl-devel-1.1.1g-15.el8_3 \
-		redhat-rpm-config-125-1.el8 \
-		glibc-all-langpacks-2.28-151.el8 \
 	"; \
 	nativeBuildDeps="$nativeBuildDeps java-${JAVA_MAJOR_PKG:-$JAVA_MAJOR}-openjdk-devel-${JRE_PKG_VERSION}"; \
 	yum install -y $nativeBuildDeps; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,7 +161,7 @@ RUN set -eux; \
 
 # verify Tomcat Native is working properly
 RUN set -e \
-	&& nativeLines="$(catalina.sh configtest 2>&1 | grep -c 'Loaded Apache Tomcat Native library')"; \
+	&& nativeLines="$(catalina.sh configtest 2>&1 | grep -c 'Loaded Apache Tomcat Native library')" \
 	&& test $nativeLines -ge 1 || exit 1
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,13 +161,8 @@ RUN set -eux; \
 
 # verify Tomcat Native is working properly
 RUN set -e \
-	&& nativeLines="$(catalina.sh configtest 2>&1)" \
-	&& nativeLines="$(echo "$nativeLines" | grep 'Apache Tomcat Native')" \
-	&& nativeLines="$(echo "$nativeLines" | sort -u)" \
-	&& if ! echo "$nativeLines" | grep 'Apache Tomcat Native library' >&2; then \
-		echo >&2 "$nativeLines"; \
-		exit 1; \
-	fi
+	&& nativeLines="$(catalina.sh configtest 2>&1 | grep -c 'Loaded Apache Tomcat Native library')"; \
+	&& test $nativeLines -ge 1 || exit 1
 
 EXPOSE 8080
 # Starting tomcat with Security Manager

--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ To build this image, run the following script:
 
 ```bash
 IMAGE_REPOSITORY=alfresco/alfresco-base-tomcat
-(cd java-$JAVA_MAJOR/$DIST_NAME-$DIST_MAJOR && docker build -t java-$JAVA_MAJOR-$DIST_NAME-$DIST_MAJOR .)
+(cd java-$JAVA_MAJOR/$DISTRIB_NAME-$DISTRIB_MAJOR && docker build -t java-$JAVA_MAJOR-$DISTRIB_NAME-$DISTRIB_MAJOR .)
 docker build -t $IMAGE_REPOSITORY . \
-  --build-arg DIST_NAME=$DIST_NAME \
-  --build-arg DIST_MAJOR=$DIST_MAJOR \
+  --build-arg DISTRIB_NAME=$DISTRIB_NAME \
+  --build-arg DISTRIB_MAJOR=$DISTRIB_MAJOR \
   --build-arg JAVA_MAJOR=$JAVA_MAJOR \
   --build-arg TOMCAT_MAJOR=$TOMCAT_MAJOR \
   --no-cache
 ```
 where:
-* DIST_NAME is centos
-* DIST_MAJOR is 7
+* DISTRIB_NAME is centos
+* DISTRIB_MAJOR is 7
 * JAVA_MAJOR is 8 or 11
 * TOMCAT_MAJOR is 8, 9 or 10
 
@@ -47,13 +47,13 @@ Builds are available from [Docker Hub](https://hub.docker.com/r/alfresco/alfresc
 
 ```bash
 docker pull alfresco/alfresco-base-tomcat:$TOMCAT_MAJOR_MINOR_VERSION 
-docker pull alfresco/alfresco-base-tomcat:$TOMCAT_VERSION-java-$JAVA_MAJOR-$DIST_NAME-$DIST_MAJOR
-docker pull alfresco/alfresco-base-tomcat:$TOMCAT_VERSION-java-$JAVA_MAJOR-$DIST_NAME-$DIST_MAJOR-$SHORT_SHA256
+docker pull alfresco/alfresco-base-tomcat:$TOMCAT_VERSION-java-$JAVA_MAJOR-$DISTRIB_NAME-$DISTRIB_MAJOR
+docker pull alfresco/alfresco-base-tomcat:$TOMCAT_VERSION-java-$JAVA_MAJOR-$DISTRIB_NAME-$DISTRIB_MAJOR-$SHORT_SHA256
 ```
 
 where:
-* DIST_NAME is centos
-* DIST_MAJOR is 7
+* DISTRIB_NAME is centos
+* DISTRIB_MAJOR is 7
 * JAVA_MAJOR is 8 or 11
 * TOMCAT_MAJOR_MINOR_VERSION is 8.5 or 9.0
 * TOMCAT_VERSION is 8.5.65, 9.0.45 or 10.0.8
@@ -67,8 +67,8 @@ The builds are identical to those stored in the private repo on Quay, which also
 
 ```bash
 docker pull quay.io/alfresco/alfresco-base-tomcat:$TOMCAT_MAJOR_MINOR_VERSION
-docker pull quay.io/alfresco/alfresco-base-tomcat:$TOMCAT_VERSION-java-$JAVA_MAJOR-$DIST_NAME-$DIST_MAJOR
-docker pull quay.io/alfresco/alfresco-base-tomcat:$TOMCAT_VERSION-java-$JAVA_MAJOR-$DIST_NAME-$DIST_MAJOR-$SHORT_SHA256
+docker pull quay.io/alfresco/alfresco-base-tomcat:$TOMCAT_VERSION-java-$JAVA_MAJOR-$DISTRIB_NAME-$DISTRIB_MAJOR
+docker pull quay.io/alfresco/alfresco-base-tomcat:$TOMCAT_VERSION-java-$JAVA_MAJOR-$DISTRIB_NAME-$DISTRIB_MAJOR-$SHORT_SHA256
 ```
 
 ## Usage

--- a/java-11/centos-7/Dockerfile
+++ b/java-11/centos-7/Dockerfile
@@ -1,2 +1,3 @@
 # Java 11 Centos 7 Base Image for Alfresco Base Tomcat Image
 FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:6abdbfd14492fb78ae5d865eb25627bb241b11da406ef8df91a77716a3538f36
+ENV JDK_HOME $JAVA_HOME

--- a/java-11/centos-7/Dockerfile
+++ b/java-11/centos-7/Dockerfile
@@ -1,2 +1,2 @@
 # Java 11 Centos 7 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:a46ba504818b78e673ab2bc83ec7c6feeb7f60ec43ce49bcc86f2f4a46c9da6f
+FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:d0a31f66317d62ca9146e12da274f70cae0e4e6636a698b3753a40f3ff9fafa6

--- a/java-11/centos-7/Dockerfile
+++ b/java-11/centos-7/Dockerfile
@@ -1,2 +1,2 @@
 # Java 11 Centos 7 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:d0a31f66317d62ca9146e12da274f70cae0e4e6636a698b3753a40f3ff9fafa6
+FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:6abdbfd14492fb78ae5d865eb25627bb241b11da406ef8df91a77716a3538f36

--- a/java-8/centos-7/Dockerfile
+++ b/java-8/centos-7/Dockerfile
@@ -1,2 +1,3 @@
 # Java 8 Centos 7 Base Image for Alfresco Base Tomcat Image
 FROM alfresco/alfresco-base-java:8.0.302-centos-7@sha256:42ca4591007d6ddcc3aebe8404de74117a3eda2a25fbba067f4fb7d2b5381986
+ENV JDK_HOME ${JAVA_HOME}/../

--- a/java-8/centos-7/Dockerfile
+++ b/java-8/centos-7/Dockerfile
@@ -1,2 +1,2 @@
 # Java 8 Centos 7 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:8.0.302-centos-7@sha256:77faf28858058aba3638bac7993ff615c32eccc4aaa9d06471559c79d217a193
+FROM alfresco/alfresco-base-java:8.0.302-centos-7@sha256:42ca4591007d6ddcc3aebe8404de74117a3eda2a25fbba067f4fb7d2b5381986

--- a/java-8/centos-7/Dockerfile
+++ b/java-8/centos-7/Dockerfile
@@ -1,2 +1,2 @@
 # Java 8 Centos 7 Base Image for Alfresco Base Tomcat Image
-FROM alfresco/alfresco-base-java:8.0.302-centos-7@sha256:17130ec70419d1d64996fc0f082ad73a94eac444decca6e2f75095dc422593c7
+FROM alfresco/alfresco-base-java:8.0.302-centos-7@sha256:77faf28858058aba3638bac7993ff615c32eccc4aaa9d06471559c79d217a193


### PR DESCRIPTION
Update the java base image to use the latest vulnerability free one that has the fixed JAVA_HOME

Ref. OPSEXP-1037