### PR TITLE
OPSEXP-1295: removes python-lxml for security reasons 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,6 @@ jobs:
         base_image:
           - flavor: centos
             major: 7
-          - flavor: debian
-            major: 11
-          - flavor: ubuntu
-            major: 20.04
           - flavor: ubi
             major: 8
         java_major:
@@ -29,12 +25,6 @@ jobs:
         jdist:
           - jre
         include:
-          - tomcat_major: 8
-            base_image:
-              flavor: centos
-              major: 7
-            java_major: 8
-            jdist: jdk
           - tomcat_major: 9
             base_image:
               flavor: centos


### PR DESCRIPTION
python-lxml has yet unresolved security issues
Also stop building and java 8, debian, ubuntu