### PR TITLE
OPSEXP-2713: harden and refactor tomcat image build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,6 @@ jobs:
             TCNATIVE_VERSION=${{ steps.vars.outputs.tcnative_version }}
             TCNATIVE_SHA512=${{ steps.vars.outputs.tcnative_sha512 }}
           tags: local/${{ env.IMAGE_REPOSITORY }}:ci
-          target: TOMCAT_BASE_IMAGE
 
       - name: Test Built Image
         env:
@@ -150,7 +149,6 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
           labels: ${{ steps.vars.outputs.image_labels }}
           provenance: false
-          target: TOMCAT_BASE_IMAGE
 
       - name: Push Image to docker.io
         if: github.ref_name == 'master'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,6 @@ repos:
     rev: v2.12.0
     hooks:
       - id: hadolint
+        args:
+          - -t
+          - warning

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,7 @@ repos:
     rev: 0.14.3
     hooks:
       - id: check-github-workflows
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@
 ARG JAVA_MAJOR
 ARG DISTRIB_NAME
 ARG DISTRIB_MAJOR
+ARG IMAGE_JAVA_REPO=quay.io/alfresco
+ARG IMAGE_JAVA_NAME=alfresco-base-java
+ARG IMAGE_JAVA_TAG=jre${JAVA_MAJOR}-${DISTRIB_NAME}${DISTRIB_MAJOR}
 
 # Tomcat is downloaded and configured on debian as its a binary dist anyway
 FROM debian:12-slim AS tomcat_dist
@@ -77,7 +80,7 @@ RUN xmlstarlet ed -L \
 # Remove unwanted files from distribution
 RUN rm -fr webapps/* *.txt *.md RELEASE-NOTES logs/ temp/ work/ bin/*.bat
 
-FROM quay.io/alfresco/alfresco-base-java:jre${JAVA_MAJOR}-${DISTRIB_NAME}${DISTRIB_MAJOR} AS tcnative_build-rockylinux
+FROM ${IMAGE_JAVA_REPO}/${IMAGE_JAVA_NAME}:${IMAGE_JAVA_TAG} AS tcnative_build-rockylinux
 ARG JAVA_MAJOR
 ENV JAVA_HOME=/usr/lib/jvm/java-openjdk
 ARG BUILD_DIR=/build
@@ -96,7 +99,7 @@ RUN yum install -y xmlstarlet gcc make openssl-devel expat-devel java-${JAVA_MAJ
 # hadolint ignore=DL3006
 FROM tcnative_build-${DISTRIB_NAME} AS tcnative_build
 
-FROM quay.io/alfresco/alfresco-base-java:jre${JAVA_MAJOR}-${DISTRIB_NAME}${DISTRIB_MAJOR} AS apr_pkg-rockylinux
+FROM ${IMAGE_JAVA_REPO}/${IMAGE_JAVA_NAME}:${IMAGE_JAVA_TAG} AS apr_pkg-rockylinux
 RUN yum install -y apr && yum clean all
 
 # hadolint ignore=DL3006

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# hadolint global ignore=DL3033
 # Alfresco Base Tomcat Image
 # see also https://github.com/docker-library/tomcat
 ARG JAVA_MAJOR
@@ -73,7 +74,7 @@ RUN chmod -R +rX . && chmod 770 logs work
 RUN mkdir -p lib/org/apache/catalina/util
 WORKDIR /build/tomcat/lib/org/apache/catalina/util
 RUN printf "server.info=Alfresco servlet container/$TOMCAT_MAJOR\nserver.number=$TOMCAT_MAJOR" > ServerInfo.properties
-RUN yum install xmlstarlet -y
+RUN yum install xmlstarlet -y && yum clean all
 RUN xmlstarlet ed -L \
   # Remove comments
   -d '//comment()' \
@@ -124,9 +125,8 @@ ENV PATH $CATALINA_HOME/bin:$PATH
 WORKDIR $CATALINA_HOME
 COPY --from=TOMCAT_BUILD /build/tomcat $CATALINA_HOME
 COPY --from=TCNATIVE_BUILD /usr/local/tcnative $TOMCAT_NATIVE_LIBDIR
-RUN \
-  set -eu; \
-  yum install -y apr; \
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+RUN yum install -y apr  && yum clean all \
   # verify Tomcat Native is working properly
   nativeLines="$(catalina.sh configtest 2>&1 | grep -c 'Loaded Apache Tomcat Native library')" && \
   test $nativeLines -ge 1 || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,6 @@ RUN xmlstarlet ed -L \
   -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]' -t attr -n deployXML -v false \
   -u '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/@autoDeploy' -v false \
   -u '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/@unpackWARs' -v false \
-  -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]' -t attr -n deployOnStartup -v false \
   # Enable RemoteIP valve for better monitoring/logging
   -s '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]' -t elem -n 'Valve' \
   -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/Valve[last()]' -t attr -n className -v org.apache.catalina.valves.RemoteIpValve \
@@ -71,9 +70,9 @@ RUN xmlstarlet ed -L \
   -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/Valve[last()]' -t attr -n showServerInfo -v false \
   -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/Valve[last()]' -t attr -n showReport -v false \
   # Do not leak runtime arguments and variables in logs
-  -a '/Server/Listener[@className=org.apache.catalina.startup.VersionLoggerListener]' -t attr -n logArgs -v false \
-  -a '/Server/Listener[@className=org.apache.catalina.startup.VersionLoggerListener]' -t attr -n logEnv -v false \
-  -a '/Server/Listener[@className=org.apache.catalina.startup.VersionLoggerListener]' -t attr -n logProps -v false \
+  -a '/Server/Listener[@className="org.apache.catalina.startup.VersionLoggerListener"]' -t attr -n logArgs -v false \
+  -a '/Server/Listener[@className="org.apache.catalina.startup.VersionLoggerListener"]' -t attr -n logEnv -v false \
+  -a '/Server/Listener[@className="org.apache.catalina.startup.VersionLoggerListener"]' -t attr -n logProps -v false \
   conf/server.xml
 # Remove unwanted files from distribution
 RUN rm -fr webapps/* *.txt *.md RELEASE-NOTES logs/ temp/ work/ bin/*.bat

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ARG BUILD_DIR=/build
 ARG INSTALL_DIR=/usr/local
 WORKDIR ${BUILD_DIR}/tcnative/native
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-RUN yum install -y gcc make openssl-devel expat-devel java-${JAVA_MAJOR}-openjdk-devel apr-devel redhat-rpm-config && yum clean all \
+RUN yum install -y gcc make openssl-devel expat-devel java-${JAVA_MAJOR}-openjdk-devel apr-devel redhat-rpm-config && yum clean all; \
   ./configure \
     --libdir=${INSTALL_DIR}/tcnative \
     --with-apr=/usr/bin/apr-1-config \
@@ -75,6 +75,7 @@ RUN mkdir -p lib/org/apache/catalina/util
 WORKDIR /build/tomcat/lib/org/apache/catalina/util
 RUN printf "server.info=Alfresco servlet container/$TOMCAT_MAJOR\nserver.number=$TOMCAT_MAJOR" > ServerInfo.properties
 RUN yum install xmlstarlet -y && yum clean all
+WORKDIR /build/tomcat
 RUN xmlstarlet ed -L \
   # Remove comments
   -d '//comment()' \
@@ -126,7 +127,7 @@ WORKDIR $CATALINA_HOME
 COPY --from=TOMCAT_BUILD /build/tomcat $CATALINA_HOME
 COPY --from=TCNATIVE_BUILD /usr/local/tcnative $TOMCAT_NATIVE_LIBDIR
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-RUN yum install -y apr  && yum clean all \
+RUN yum install -y apr  && yum clean all; \
   # verify Tomcat Native is working properly
   nativeLines="$(catalina.sh configtest 2>&1 | grep -c 'Loaded Apache Tomcat Native library')" && \
   test $nativeLines -ge 1 || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ARG TCNATIVE_SHA512
 
 FROM base AS tomcat
 ARG APACHE_MIRRORS
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 RUN \
-  set -eu; \
   mkdir -p /build/{tcnative,tomcat}; \
   active_mirror=; \
   for mirror in $APACHE_MIRRORS; do \
@@ -50,10 +50,9 @@ ARG JAVA_MAJOR
 ENV JAVA_HOME /usr/lib/jvm/java-openjdk
 ARG BUILD_DIR=/build
 ARG INSTALL_DIR=/usr/local
-RUN set -eu; \
-  cd $BUILD_DIR; \
-  yum install -y gcc make openssl-devel expat-devel java-${JAVA_MAJOR}-openjdk-devel apr-devel redhat-rpm-config; \
-  cd tcnative/native; \
+WORKDIR ${BUILD_DIR}/tcnative/native
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+RUN yum install -y gcc make openssl-devel expat-devel java-${JAVA_MAJOR}-openjdk-devel apr-devel redhat-rpm-config; \
   ./configure \
     --libdir=${INSTALL_DIR}/tcnative \
     --with-apr=/usr/bin/apr-1-config \

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,15 +109,15 @@ ARG CREATED
 ARG REVISION
 LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.name="Alfresco Base Tomcat Image" \
-  org.label-schema.vendor="Alfresco" \
+  org.label-schema.vendor="Hyland" \
   org.label-schema.build-date="$CREATED" \
   org.opencontainers.image.title="Alfresco Base Tomcat Image" \
-  org.opencontainers.image.vendor="Alfresco" \
+  org.opencontainers.image.vendor="Hyland" \
   org.opencontainers.image.revision="$REVISION" \
   org.opencontainers.image.source="https://github.com/Alfresco/alfresco-docker-base-tomcat" \
   org.opencontainers.image.created="$CREATED"
-# let "Tomcat Native" live somewhere isolated
 ENV CATALINA_HOME=/usr/local/tomcat
+# let "Tomcat Native" live somewhere isolated
 ENV TOMCAT_NATIVE_LIBDIR=$CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH=$TOMCAT_NATIVE_LIBDIR
 ENV PATH=$CATALINA_HOME/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ARG BUILD_DIR=/build
 ARG INSTALL_DIR=/usr/local
 WORKDIR ${BUILD_DIR}/tcnative/native
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-RUN yum install -y gcc make openssl-devel expat-devel java-${JAVA_MAJOR}-openjdk-devel apr-devel redhat-rpm-config; \
+RUN yum install -y gcc make openssl-devel expat-devel java-${JAVA_MAJOR}-openjdk-devel apr-devel redhat-rpm-config && yum clean all \
   ./configure \
     --libdir=${INSTALL_DIR}/tcnative \
     --with-apr=/usr/bin/apr-1-config \
@@ -70,7 +70,7 @@ RUN find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' 
 RUN chmod -R +rX . && chmod 770 logs work
 # Security improvements:
 # Remove server banner, Turn off loggin by the VersionLoggerListener, enable remoteIP valve so we know who we're talking to
-RUN mkdir -p lib/org/apache/catalina/util && cd $_ && echo -e "server.info=Alfresco servlet container/$TOMCAT_MAJOR\nserver.number=$TOMCAT_MAJOR" > ServerInfo.properties
+RUN mkdir -p lib/org/apache/catalina/util && cd $_ && echo "server.info=Alfresco servlet container/$TOMCAT_MAJOR\nserver.number=$TOMCAT_MAJOR" > ServerInfo.properties
 RUN dnf install xmlstarlet -y
 RUN xmlstarlet ed -L \
   # Remove comments

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,14 +107,25 @@ FROM apr_pkg-${DISTRIB_NAME}
 ARG DISTRIB_MAJOR
 ARG CREATED
 ARG REVISION
+ARG LABEL_NAME="Alfresco Base Tomcat Image"
+ARG LABEL_DESC="Apache Tomcat Image tailored for Alfresco products"
+ARG LABEL_VENDOR="Hyland"
+ARG LABEL_SOURCE="https://github.com/Alfresco/alfresco-docker-base-tomcat"
 LABEL org.label-schema.schema-version="1.0" \
-  org.label-schema.name="Alfresco Base Tomcat Image" \
-  org.label-schema.vendor="Hyland" \
+  org.label-schema.name="$LABEL_NAME" \
+  org.label-schema.description="$LABEL_DESC" \
+  org.label-schema.vendor="$LABEL_VENDOR" \
   org.label-schema.build-date="$CREATED" \
-  org.opencontainers.image.title="Alfresco Base Tomcat Image" \
-  org.opencontainers.image.vendor="Hyland" \
+  org.label-schema.url="$LABEL_SOURCE" \
+  org.label-schema.vcs-url="$LABEL_SOURCE" \
+  org.label-schema.vcs-ref="$LABEL_SOURCE" \
+  org.opencontainers.image.title="$LABEL_NAME" \
+  org.opencontainers.image.description="$LABEL_DESC" \
+  org.opencontainers.image.vendor="$LABEL_VENDOR" \
+  org.opencontainers.image.authors="Alfresco OPS-Readiness" \
   org.opencontainers.image.revision="$REVISION" \
-  org.opencontainers.image.source="https://github.com/Alfresco/alfresco-docker-base-tomcat" \
+  org.opencontainers.image.url="$LABEL_SOURCE" \
+  org.opencontainers.image.source="$LABEL_SOURCE" \
   org.opencontainers.image.created="$CREATED"
 ENV CATALINA_HOME=/usr/local/tomcat
 # let "Tomcat Native" live somewhere isolated

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,7 @@ ARG DISTRIB_MAJOR
 ARG TOMCAT_MAJOR
 
 FROM quay.io/alfresco/alfresco-base-java:jre${JAVA_MAJOR}-${DISTRIB_NAME}${DISTRIB_MAJOR} AS base
-ENV APACHE_MIRRORS \
-  https://archive.apache.org/dist \
-  https://dlcdn.apache.org \
-  https://downloads.apache.org
+ENV APACHE_MIRRORS="https://archive.apache.org/dist https://dlcdn.apache.org https://downloads.apache.org"
 
 ARG TOMCAT_MAJOR
 ARG TOMCAT_VERSION
@@ -48,7 +45,7 @@ RUN \
 
 FROM tomcat AS tcnative_build
 ARG JAVA_MAJOR
-ENV JAVA_HOME /usr/lib/jvm/java-openjdk
+ENV JAVA_HOME=/usr/lib/jvm/java-openjdk
 ARG BUILD_DIR=/build
 ARG INSTALL_DIR=/usr/local
 WORKDIR ${BUILD_DIR}/tcnative/native
@@ -119,10 +116,10 @@ LABEL org.label-schema.schema-version="1.0" \
   org.opencontainers.image.source="https://github.com/Alfresco/alfresco-docker-base-tomcat" \
   org.opencontainers.image.created="$CREATED"
 # let "Tomcat Native" live somewhere isolated
-ENV CATALINA_HOME /usr/local/tomcat
-ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
-ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
-ENV PATH $CATALINA_HOME/bin:$PATH
+ENV CATALINA_HOME=/usr/local/tomcat
+ENV TOMCAT_NATIVE_LIBDIR=$CATALINA_HOME/native-jni-lib
+ENV LD_LIBRARY_PATH=$TOMCAT_NATIVE_LIBDIR
+ENV PATH=$CATALINA_HOME/bin:$PATH
 WORKDIR $CATALINA_HOME
 COPY --from=tomcat_build /build/tomcat $CATALINA_HOME
 COPY --from=tcnative_build /usr/local/tcnative $TOMCAT_NATIVE_LIBDIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,10 @@ RUN find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' 
 RUN chmod -R +rX . && chmod 770 logs work
 # Security improvements:
 # Remove server banner, Turn off loggin by the VersionLoggerListener, enable remoteIP valve so we know who we're talking to
-RUN mkdir -p lib/org/apache/catalina/util && cd $_ && echo "server.info=Alfresco servlet container/$TOMCAT_MAJOR\nserver.number=$TOMCAT_MAJOR" > ServerInfo.properties
-RUN dnf install xmlstarlet -y
+RUN mkdir -p lib/org/apache/catalina/util
+WORKDIR /build/tomcat/lib/org/apache/catalina/util
+RUN printf "server.info=Alfresco servlet container/$TOMCAT_MAJOR\nserver.number=$TOMCAT_MAJOR" > ServerInfo.properties
+RUN yum install xmlstarlet -y
 RUN xmlstarlet ed -L \
   # Remove comments
   -d '//comment()' \

--- a/README.md
+++ b/README.md
@@ -106,6 +106,20 @@ match the following requirements:
   (for production we using JRE over JDK) as per the [Alfresco compatibility
   matrix](https://docs.alfresco.com/content-services/latest/support/)
 
+#### Specifying the new base image
+
+In addition to the build arguments documented in the [build
+time](#how-to-build-an-image-locally), you need to tell the build process where
+the java base image can be found (if it's not present on the Alfresco image
+registry). The following build arguments are available:
+
+* IMAGE_JAVA_REPO: the repository where the base image can be found (default is
+  quay.io/alfresco)
+* IMAGE_JAVA_NAME: the name of the base image to use (default is
+  alfresco-base-java)
+* IMAGE_JAVA_TAG: the tag of the base image to use (default is
+  jre${JAVA_MAJOR}-${DISTRIB_NAME}${DISTRIB_MAJOR})
+
 #### Implementing Tomcat native libs build stage
 
 You'll need to create a new stage in the Dockerfile that will be used to build

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ diagram below:
 ```mermaid
 flowchart TB
 
-classDef custom fill:lightgrey,stroke:#f66,stroke-width:2px,stroke-dasharray: 5 5
+classDef custom fill:lightgrey,color:black,stroke:darkgrey,stroke-width:2px,stroke-dasharray: 5 5
 
 subgraph Tomcat configuration process
 debian(Debian 12 slim image)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ installed in the `tomcat_dist` image are not present in the final image.
 
 This project lets you use a different base distribution/image to create your
 Alfresco Tomcat base image.
-To do that you need to create additionnal, distro specific, stages in the
+To do that you need to create additional, distro specific, stages in the
 multi-stage build and name them according to the build arguments you want to
 use at [build time](#how-to-build-an-image-locally).
 
@@ -128,7 +128,7 @@ the Tomcat native libraries. This stage should be named
 distribution you want to use. Take a look at the existing
 `tcnative_build-rockylinux` stage for an example, but overall the goal is to
 install on your target distribution the required packages to build the Tomcat
-native libraries in a the `/usr/local/tcnative` directory, so it can be copied
+native libraries in the `/usr/local/tcnative` directory, so it can be copied
 to the final image.
 
 For example:


### PR DESCRIPTION
Ref: OPSEXP-2713

Downstream projects relying on tomcat base image would have to add a `USER root` directive before doing any `RUN` to avoid permissions issues.