### PR TITLE
OPSEXP-3032 RemoteIpValve to Use X-Forwarded-Port for port resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,10 @@ RUN xmlstarlet ed -L \
   -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]' -t attr -n deployXML -v false \
   -u '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/@autoDeploy' -v false \
   -u '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/@unpackWARs' -v false \
-  # Enable RemoteIP valve for better monitoring/logging
+  # Enable RemoteIP valve for better handling when behind reverse proxy
   -s '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]' -t elem -n 'Valve' \
   -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/Valve[last()]' -t attr -n className -v org.apache.catalina.valves.RemoteIpValve \
+  -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/Valve[last()]' -t attr -n portHeader -v X-Forwarded-Port \
   # Do not leak server info within error pages
   -s '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]' -t elem -n 'Valve' \
   -a '/Server/Service[@name="Catalina"]/Engine[@name="Catalina"]/Host[@name="localhost"]/Valve[last()]' -t attr -n className -v org.apache.catalina.valves.ErrorReportValve \


### PR DESCRIPTION
Ensures that `RemoteIpValve` considers the `X-Forwarded-Port` header, rather than relying solely on `X-Forwarded-Proto`, to determine the proxied client's port.

The issue became visible after switching to Traefik as the default reverse proxy in the Alfresco Docker Compose setup. Unlike the previously used `acs-ingress`, which did not set any `X-Forwarded-Proto`, `RemoteIpValve` was dynamically adjusting the port, forcing it to be either 443 or 80, leading to application inconsistencies.

This change improves compatibility with reverse proxies that explicitly provide the forwarded port, ensuring more accurate port resolution.

ref OPSEXP-3032