### PR TITLE
OPSEXP-3172: fix shipping devel packages/files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,6 +140,22 @@ jobs:
             exit 7
           fi
 
+      - name: Check Image size
+        env:
+          IMAGE_ARCH: ${{ runner.arch == 'X64' && 'amd64' || 'arm64' }}
+          TOMCAT: tomcat${{ matrix.tomcat_major }}
+          JAVA: jre${{ matrix.java_major }}
+          DISTRIBUTION: ${{ matrix.base_image.flavor }}${{ matrix.base_image.major }}
+        run: |
+          IMAGE_NEW_SIZE=$(docker save local/${{ env.IMAGE_REPOSITORY }}:ci | gzip -c | wc -c)
+          IMAGE_PREV_SHA=$(docker manifest inspect ${IMAGE_REGISTRY_NAMESPACE}/${IMAGE_REPOSITORY}:${TOMCAT}-${JAVA}-${DISTRIBUTION} | jq -r '.manifests|map(select(.platform.architecture=="amd64"))[0].digest')
+          IMAGE_PREV_SIZE=$(docker manifest inspect ${IMAGE_REGISTRY_NAMESPACE}/${IMAGE_REPOSITORY}@${IMAGE_PREV_SHA} | jq '.layers|map(.size)|add')
+          if [ $(($IMAGE_NEW_SIZE*10)) -gt $(($IMAGE_PREV_SIZE*11)) ]; then
+            echo "Image size increased beyon 10% (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE)"
+            exit 1
+          fi
+
+
       - name: Build and Push Image to quay.io
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,14 +147,18 @@ jobs:
           JAVA: jre${{ matrix.java_major }}
           DISTRIBUTION: ${{ matrix.base_image.flavor }}${{ matrix.base_image.major }}
         run: |
-          IMAGE_NEW_SIZE=$(docker save local/${{ env.IMAGE_REPOSITORY }}:ci | gzip -c | wc -c)
           IMAGE_PREV_SHA=$(docker manifest inspect ${IMAGE_REGISTRY_NAMESPACE}/${IMAGE_REPOSITORY}:${TOMCAT}-${JAVA}-${DISTRIBUTION} | jq -r '.manifests|map(select(.platform.architecture=="amd64"))[0].digest')
-          IMAGE_PREV_SIZE=$(docker manifest inspect ${IMAGE_REGISTRY_NAMESPACE}/${IMAGE_REPOSITORY}@${IMAGE_PREV_SHA} | jq '.layers|map(.size)|add')
-          if [ $(($IMAGE_NEW_SIZE*10)) -gt $(($IMAGE_PREV_SIZE*11)) ]; then
-            echo "Image size increased beyon 10% (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE)"
-            exit 1
+          if [ -z "$IMAGE_PREV_SHA" ]; then
+            echo "No previous image found, skipping check"
+            exit 0
+          else echo "Previous image found: $IMAGE_PREV_SHA"
+            IMAGE_PREV_SIZE=$(docker manifest inspect ${IMAGE_REGISTRY_NAMESPACE}/${IMAGE_REPOSITORY}@${IMAGE_PREV_SHA} | jq '.layers|map(.size)|add')
+            IMAGE_NEW_SIZE=$(docker save local/${{ env.IMAGE_REPOSITORY }}:ci | gzip -c | wc -c)
+            if [ $(($IMAGE_NEW_SIZE*10)) -gt $(($IMAGE_PREV_SIZE*11)) ]; then
+              echo "Image size increased beyon 10% (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE)"
+              exit 1
+            fi
           fi
-
 
       - name: Build and Push Image to quay.io
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,6 +157,7 @@ jobs:
             if [ $(($IMAGE_NEW_SIZE*10)) -gt $(($IMAGE_PREV_SIZE*11)) ]; then
               echo "Image size increased beyon 10% (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE)"
               exit 1
+            else echo "Image size increase within 10% or below (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE)"
             fi
           fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN <<EOT
     ln -s /usr/include/openssl3/openssl /usr/include/openssl
     export LIBS="-L/usr/lib64/openssl3 -Wl,-rpath,/usr/lib64/openssl3 -lssl -lcrypto"
     export CFLAGS="-I/usr/include/openssl3"
-    else dnf install -y openssl-devel
+  else dnf install -y openssl-devel
   fi
   dnf clean all
   ./configure \
@@ -133,7 +133,7 @@ EOT
 FROM tcnative_build-${DISTRIB_NAME} AS tcnative_build
 
 # hadolint ignore=DL3006
-FROM tcnative_build
+FROM ${IMAGE_JAVA_REPO}/${IMAGE_JAVA_NAME}:${IMAGE_JAVA_TAG}
 ARG DISTRIB_MAJOR
 ARG CREATED
 ARG REVISION
@@ -159,8 +159,8 @@ LABEL org.label-schema.schema-version="1.0" \
   org.opencontainers.image.created="$CREATED"
 ENV CATALINA_HOME=/usr/local/tomcat
 # let "Tomcat Native" live somewhere isolated
-ENV TOMCAT_NATIVE_LIBDIR=$CATALINA_HOME/native-jni-lib
-ENV APR_LIBDIR=$CATALINA_HOME/apr
+ENV TOMCAT_NATIVE_LIBDIR=/usr/local/native-jni-lib
+ENV APR_LIBDIR=/usr/local/apr
 ENV LD_LIBRARY_PATH=$TOMCAT_NATIVE_LIBDIR:$APR_LIBDIR
 ENV PATH=$CATALINA_HOME/bin:$PATH
 WORKDIR $CATALINA_HOME
@@ -170,7 +170,7 @@ RUN groupadd --system tomcat && \
   useradd -M -s /bin/false --home $CATALINA_HOME --system --gid tomcat tomcat
 COPY --chown=:tomcat --chmod=640 --from=tomcat_dist /build/tomcat $CATALINA_HOME
 COPY --chown=:tomcat --chmod=640 --from=tcnative_build /usr/local/tcnative $TOMCAT_NATIVE_LIBDIR
-COPY --chown=:tomcat --chmod=640 --from=tcnative_build /usr/local/apr $APR_LIBDIR
+COPY --chown=:tomcat --chmod=640 --from=tcnative_build /usr/local/apr/lib $APR_LIBDIR
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 RUN <<EOT
   if [ $DISTRIB_MAJOR -eq 8 ]; then


### PR DESCRIPTION
Ref: OPSEXP-3172

make sure build files  remain part of build stages and add a check in case image grows bigger than 110% of tits previous version