### PR TITLE
OPSEXP-3292 Bump stefanzweifel/git-auto-commit-action version to v6

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -63,11 +63,11 @@ jobs:
         run: |
           echo "TOMCAT_VERSION=$(jq -r '.tomcat_version' tomcat${{ matrix.tomcat_major }}.json)" >> $GITHUB_ENV
 
-      - uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5.1.0
-        id: auto-commit-action
+      - id: auto-commit-action
+        name: Git Auto Commit
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
         with:
           branch: bump-tomcat-${{ env.TOMCAT_VERSION }}
-          create_branch: true
           push_options: '--force'
           commit_user_name: ${{ vars.BOT_GITHUB_USERNAME }}
           commit_user_email: ${{ vars.BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
### Related Issue
[OPSEXP-3292]

Review usage of **stefanzweifel/git-auto-commit-action** and bump version to v6
Please refer release notes [Release v6.0.0 · stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v6.0.0)
### Changes introduced
Updated stefanzweifel/git-auto-commit-action to [stefanzweifel/git-auto-commit-action@778341a](https://github.com/stefanzweifel/git-auto-commit-action/commit/778341af668090896ca464160c2def5d1d1a3eb0) (#v6.0.1) in below workflow

.github/workflows/bumpVersions.yml

[OPSEXP-3292]: https://hyland.atlassian.net/browse/OPSEXP-3292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ