### PR TITLE
Fix tomcat bump PRs creation

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -63,11 +63,15 @@ jobs:
         run: |
           echo "TOMCAT_VERSION=$(jq -r '.tomcat_version' tomcat${{ matrix.tomcat_major }}.json)" >> $GITHUB_ENV
 
+      - name: Set target branch
+        run: |
+          echo "TARGET_BRANCH=bump-tomcat-${{ env.TOMCAT_VERSION }}" >> $GITHUB_ENV
+
       - id: auto-commit-action
         name: Git Auto Commit
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
         with:
-          branch: bump-tomcat-${{ env.TOMCAT_VERSION }}
+          branch: ${{ env.TARGET_BRANCH }}
           push_options: '--force'
           commit_user_name: ${{ vars.BOT_GITHUB_USERNAME }}
           commit_user_email: ${{ vars.BOT_GITHUB_EMAIL }}
@@ -76,7 +80,7 @@ jobs:
         if: steps.auto-commit-action.outputs.changes_detected == 'true'
         run: |
           if ! gh pr view --json url --jq .url; then
-            gh pr create --title "Bump tomcat to ${{ env.TOMCAT_VERSION }}" --body "Freshly served thanks to updatecli and GitHub Actions"
+            gh pr create --head ${{ env.TARGET_BRANCH }} --title "Bump tomcat to ${{ env.TOMCAT_VERSION }}" --body "Freshly served thanks to updatecli and GitHub Actions"
           fi
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
I think it was broken since https://github.com/Alfresco/alfresco-docker-base-tomcat/pull/253 as action is not checking out anymore the destination branch as before