### PR TITLE
Fix existing PR check in bump tomcat workflow

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -79,7 +79,8 @@ jobs:
       - name: Autocreate PR
         if: steps.auto-commit-action.outputs.changes_detected == 'true'
         run: |
-          if ! gh pr view --json url --jq .url; then
+          PR_EXISTS=$(gh pr list --head ${{ env.TARGET_BRANCH }} --json url --jq 'length')
+          if [ "$PR_EXISTS" -eq 0 ]; then
             gh pr create --head ${{ env.TARGET_BRANCH }} --title "Bump tomcat to ${{ env.TOMCAT_VERSION }}" --body "Freshly served thanks to updatecli and GitHub Actions"
           fi
         env:


### PR DESCRIPTION
https://github.com/Alfresco/alfresco-docker-base-tomcat/actions/runs/17726889322/job/50369378646#step:11:15

`gh pr view` doesn't have a `--head` argument so it won't behave properly.