### PR TITLE
Fix OpenSSL version mismatch for Tomcat Native

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: check-github-workflows
   - repo: https://github.com/hadolint/hadolint
-    rev: v2.12.0
+    rev: v2.14.0
     hooks:
       - id: hadolint
         args:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# hadolint global ignore=DL3033,DL3008
+# hadolint global ignore=DL3033,DL3008,DL3041
 # Alfresco Base Tomcat Image
 # see also https://github.com/docker-library/tomcat
 ARG JAVA_MAJOR
@@ -194,6 +194,8 @@ RUN groupadd --system tomcat && \
 
 COPY --chown=:tomcat --chmod=640 --from=tomcat_dist /build/tomcat $CATALINA_HOME
 COPY --chown=:tomcat --chmod=640 --from=tcnative_build /usr/local/tcnative $TOMCAT_NATIVE_LIBDIR
+COPY --chown=:tomcat --chmod=640 --from=tcnative_build /usr/lib64/libssl.so.3 $TOMCAT_NATIVE_LIBDIR/
+COPY --chown=:tomcat --chmod=640 --from=tcnative_build /usr/lib64/libcrypto.so.3 $TOMCAT_NATIVE_LIBDIR/
 COPY --chown=:tomcat --chmod=640 --from=tcnative_build /usr/local/apr/lib/libapr-1.so* $APR_LIBDIR/
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]


### PR DESCRIPTION
EPEL repository provides OpenSSL 3.3.x headers (openssl-devel) on EL9,
causing tcnative to be compiled against OPENSSL_3.3.0 symbols. However,
the final image based on Rocky Linux 9 only ships openssl-libs 3.0.7,
resulting in a runtime symbol resolution failure:
  "version `OPENSSL_3.3.0' not found"

Fix by copying the OpenSSL shared libraries (libssl.so.3, libcrypto.so.3)
from the tcnative build stage into the final image's native-jni-lib
directory, which is already on LD_LIBRARY_PATH. This ensures tcnative
always loads the exact OpenSSL version it was compiled against.