### PR TITLE
refactor(OPSEXP-4054): switch CI trigger from push to pull_request

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
             SKIP_SIZE_CHECK="${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-image-size-check') }}"
             if [ "$IMAGE_NEW_SIZE" -gt "$ALLOWED_SIZE" ]; then
               if [ "$SKIP_SIZE_CHECK" == "true" ]; then
-                echo "WARNING: Image size increased beyond ${IMAGE_SIZE_MAX_PERCENT}% (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE, allowed: $ALLOWED_SIZE). Continuing because label 'ci/skip-image-size-check' is set."
+                echo "::warning::Image size increased beyond ${IMAGE_SIZE_MAX_PERCENT}% (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE, allowed: $ALLOWED_SIZE). Continuing because label 'ci/skip-image-size-check' is set."
               else
                 echo "Image size increased beyond ${IMAGE_SIZE_MAX_PERCENT}% (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE, allowed: $ALLOWED_SIZE)"
                 exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ env:
   IMAGE_REPOSITORY: alfresco-base-tomcat
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,14 @@
 name: Build the tomcats
 on:
   push:
+    branches:
+      - master
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.github/workflows/main.yml'
+      - 'tomcat*.json'
+  pull_request:
     paths:
       - 'Dockerfile'
       - '.dockerignore'
@@ -90,7 +98,7 @@ jobs:
             echo "image_tag=$IMAGE_BASE_NAME" >> $GITHUB_OUTPUT
             echo "image_labels=" >> $GITHUB_OUTPUT
           else
-            echo "image_tag=${IMAGE_BASE_NAME}-${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT
+            echo "image_tag=${IMAGE_BASE_NAME}-${GITHUB_HEAD_REF//\//-}" >> $GITHUB_OUTPUT
             echo "image_labels=quay.expires-after=2w" >> $GITHUB_OUTPUT
           fi
           echo "image_created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
@@ -154,7 +162,7 @@ jobs:
           TOMCAT: tomcat${{ matrix.tomcat_major }}
           JAVA: jre${{ matrix.java_major }}
           DISTRIBUTION: ${{ matrix.base_image.flavor }}${{ matrix.base_image.major }}
-          IMAGE_SIZE_MAX_PERCENT: 50
+          IMAGE_SIZE_MAX_PERCENT: 10
         run: |
           IMAGE_PREV_SHA=$(docker manifest inspect ${IMAGE_REGISTRY_NAMESPACE}/${IMAGE_REPOSITORY}:${TOMCAT}-${JAVA}-${DISTRIBUTION} | jq -r '.manifests|map(select(.platform.architecture=="amd64"))[0].digest')
           if [ -z "$IMAGE_PREV_SHA" ]; then
@@ -165,9 +173,14 @@ jobs:
             IMAGE_NEW_SIZE=$(docker save local/${{ env.IMAGE_REPOSITORY }}:ci | gzip -c | wc -c)
             # Calculate allowed size increase
             ALLOWED_SIZE=$((IMAGE_PREV_SIZE + (IMAGE_PREV_SIZE * IMAGE_SIZE_MAX_PERCENT / 100)))
+            SKIP_SIZE_CHECK="${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-image-size-check') }}"
             if [ "$IMAGE_NEW_SIZE" -gt "$ALLOWED_SIZE" ]; then
-              echo "Image size increased beyond ${IMAGE_SIZE_MAX_PERCENT}% (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE, allowed: $ALLOWED_SIZE)"
-              exit 1
+              if [ "$SKIP_SIZE_CHECK" == "true" ]; then
+                echo "WARNING: Image size increased beyond ${IMAGE_SIZE_MAX_PERCENT}% (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE, allowed: $ALLOWED_SIZE). Continuing because label 'ci/skip-image-size-check' is set."
+              else
+                echo "Image size increased beyond ${IMAGE_SIZE_MAX_PERCENT}% (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE, allowed: $ALLOWED_SIZE)"
+                exit 1
+              fi
             else echo "Image size increase within ${IMAGE_SIZE_MAX_PERCENT}% or below (from $IMAGE_PREV_SIZE to $IMAGE_NEW_SIZE, allowed: $ALLOWED_SIZE)"
             fi
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,7 @@ jobs:
           echo "apr_sha256=$(jq -r .apr_sha256 tomcat${{ matrix.tomcat_major }}.json)" >> $GITHUB_OUTPUT
 
       - name: Login to quay.io
+        if: ${{ secrets.QUAY_USERNAME != '' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: quay.io
@@ -188,7 +189,7 @@ jobs:
       - name: Build and Push Image to quay.io
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
-          push: ${{ github.actor != 'dependabot[bot]' }}
+          push: ${{ github.actor != 'dependabot[bot]' && secrets.QUAY_USERNAME != '' }}
           build-args: |
             DISTRIB_NAME=${{ matrix.base_image.flavor }}
             DISTRIB_MAJOR=${{ matrix.base_image.major }}
@@ -209,7 +210,7 @@ jobs:
           provenance: false
 
       - name: Push additional timestamped tag to quay.io
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'master' && secrets.QUAY_USERNAME != ''
         env:
           SRC_IMAGE: quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}
           DST_IMAGE: quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}-${{ steps.vars.outputs.timestamp }}
@@ -218,14 +219,14 @@ jobs:
 
 
       - name: Login to docker.io
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'master' && secrets.DOCKER_USERNAME != ''
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push images to docker.io
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'master' && secrets.DOCKER_USERNAME != ''
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           SRC_IMAGE: quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,9 @@ jobs:
               major: 9
             java_major: 25
     runs-on: ubuntu-latest
+    env:
+      HAS_QUAY_CREDS: ${{ secrets.QUAY_USERNAME != '' }}
+      HAS_DOCKER_CREDS: ${{ secrets.DOCKER_USERNAME != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -114,7 +117,7 @@ jobs:
           echo "apr_sha256=$(jq -r .apr_sha256 tomcat${{ matrix.tomcat_major }}.json)" >> $GITHUB_OUTPUT
 
       - name: Login to quay.io
-        if: ${{ secrets.QUAY_USERNAME != '' }}
+        if: env.HAS_QUAY_CREDS == 'true'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: quay.io
@@ -189,7 +192,7 @@ jobs:
       - name: Build and Push Image to quay.io
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
-          push: ${{ github.actor != 'dependabot[bot]' && secrets.QUAY_USERNAME != '' }}
+          push: ${{ github.actor != 'dependabot[bot]' && env.HAS_QUAY_CREDS == 'true' }}
           build-args: |
             DISTRIB_NAME=${{ matrix.base_image.flavor }}
             DISTRIB_MAJOR=${{ matrix.base_image.major }}
@@ -210,7 +213,7 @@ jobs:
           provenance: false
 
       - name: Push additional timestamped tag to quay.io
-        if: github.ref_name == 'master' && secrets.QUAY_USERNAME != ''
+        if: github.ref_name == 'master' && env.HAS_QUAY_CREDS == 'true'
         env:
           SRC_IMAGE: quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}
           DST_IMAGE: quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}-${{ steps.vars.outputs.timestamp }}
@@ -219,14 +222,14 @@ jobs:
 
 
       - name: Login to docker.io
-        if: github.ref_name == 'master' && secrets.DOCKER_USERNAME != ''
+        if: github.ref_name == 'master' && env.HAS_DOCKER_CREDS == 'true'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push images to docker.io
-        if: github.ref_name == 'master' && secrets.DOCKER_USERNAME != ''
+        if: github.ref_name == 'master' && env.HAS_DOCKER_CREDS == 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           SRC_IMAGE: quay.io/${{ env.IMAGE_REGISTRY_NAMESPACE }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}


### PR DESCRIPTION
OPSEXP-4054

## Summary

Rewrites the main workflow trigger strategy and improves the image size check.

### Trigger changes
- Add `pull_request` trigger (path-filtered) for PR validation — provides `github.event.pull_request` context (labels, head ref, etc.)
- Limit `push` trigger to `master` branch only (deployment after merge)
- `schedule` trigger unchanged

### Other changes
- **Image tag**: use `GITHUB_HEAD_REF` instead of `GITHUB_REF_NAME` for non-master tag suffix; on `pull_request` events `GITHUB_REF_NAME` is the merge ref (e.g. `123/merge`) while `GITHUB_HEAD_REF` is the actual branch name
- **Revert** `IMAGE_SIZE_MAX_PERCENT` from 50 back to 10
- **Label bypass**: add `ci/skip-image-size-check` label — when set on a PR, the image size check prints a `WARNING` instead of failing; on `push` and `schedule` events the expression evaluates to `false` so the hard failure is preserved
- **Concurrency group**: use `github.event.pull_request.number || github.ref_name` instead of `github.ref_name` to avoid the `123/merge` artefact on PR events
- **Login/push steps conditional**: skip quay.io login, image push, and docker.io login/push when the corresponding secrets are not set, allowing the workflow to complete build and test steps in fork PRs or credential-less environments (uses job-level `HAS_QUAY_CREDS`/`HAS_DOCKER_CREDS` env vars to work around the `secrets` context not being available in step `if:` conditions)